### PR TITLE
add 'updateUserAvatarUrl' resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.6.0] - 2020-05-03
+
+### Changes
+
+Add 'updateUserAvatarUrl' resolver e4e7798
+
 ## [v0.5.0] - 2020-05-02
 
 ### Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamodb-graphql-server",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "",
   "main": "index.ts",
   "scripts": {

--- a/src/resolvers/Mutation/snacks/index.ts
+++ b/src/resolvers/Mutation/snacks/index.ts
@@ -1,5 +1,7 @@
 export { createProduct } from "./createProduct"
-export { createUser } from "./createUser"
 export { createTable } from "./createTable"
-export { updateProduct } from "./updateProduct"
+export { createUser } from "./createUser"
 export { createVote } from "./createVote"
+
+export { updateProduct } from "./updateProduct"
+export { updateUserAvatarUrl } from "./updateUserAvatarUrl"

--- a/src/resolvers/Mutation/snacks/updateUserAvatarUrl.ts
+++ b/src/resolvers/Mutation/snacks/updateUserAvatarUrl.ts
@@ -1,0 +1,77 @@
+import DynamoDB from "aws-sdk/clients/dynamodb"
+
+import type { ResolverFn } from "resolvers/ResolverFn"
+
+import { TABLE_NAMES } from "../.."
+import { getAuthPayload } from "../../../utils"
+
+type Args = {
+  avatarUrl: string
+}
+export const updateUserAvatarUrl: ResolverFn<any, Args> = async (
+  obj,
+  { avatarUrl },
+  context,
+  { fieldName, parentType }
+) => {
+  const { docClient } = context
+  const { username, email } = getAuthPayload(context)
+
+  const params: DynamoDB.DocumentClient.UpdateItemInput = {
+    TableName: TABLE_NAMES.Snacks,
+    Key: {
+      PK: `USER#${username}`,
+      SK: `#USER`,
+    },
+    /**
+     * ConditionExpression
+     * @see https://stackoverflow.com/a/46531548/9823455
+     * @type {String}
+     * - A condition that must be satisfied in order for a conditional PutItem operation to succeed.
+     *   - True => put succeeds
+     *
+     * An expression can contain any of the following:
+     *
+     * Functions: attribute_exists | attribute_not_exists | attribute_type | contains | begins_with | size
+     * These function names are case-sensitive.
+     *
+     * Comparison operators: ` = | <> | < | > | <= | >= | BETWEEN | IN `
+     * Logical operators: ` AND | OR | NOT`
+     *
+     * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html
+     */
+    // ConditionExpression: "#PK <> :pk", // put succeed if # !== :
+    UpdateExpression: "SET #UpdatedAt = :now, avatarUrl = :url",
+    /**
+     * use this to avoid the error:
+     * _"Invalid ConditionExpression: Attribute name is a reserved keyword;_
+     */
+    ExpressionAttributeNames: {
+      "#UpdatedAt": "updatedAt",
+    },
+    ExpressionAttributeValues: {
+      ":now": new Date().toISOString(),
+      ":url": avatarUrl,
+    },
+
+    /**
+     * Required to return a value
+     * NONE | ALL_OLD | UPDATED_OLD | ALL_NEW | UPDATED_NEW
+     *
+     * https://stackoverflow.com/a/55171022/9823455
+     */
+    ReturnValues: "ALL_NEW",
+  }
+
+  return docClient
+    .update(params)
+    .promise()
+    .then(res => {
+      console.info(parentType.name, fieldName, res)
+      return res.Attributes
+    })
+    .catch(err => {
+      console.error(parentType.name, fieldName, err.message)
+      throw err
+    })
+}

--- a/src/schema.graphql.ts
+++ b/src/schema.graphql.ts
@@ -57,6 +57,7 @@ export const typeDefs = gql`
     firstName: String
     lastName: String
     email: String
+    avatarUrl: String
   }
 
   type Vote {
@@ -83,6 +84,7 @@ export const typeDefs = gql`
     createUser(username: String!, email: String!): User @development
     createVote(productName: String!, username: String!): Vote @auth
     updateProduct(productName: String!): Product @auth
+    updateUserAvatarUrl(avatarUrl: String!): User @auth
     #
     login(email: String!, password: String!, username: String!): AuthPayload
     signup(


### PR DESCRIPTION
# Description

### This blocks https://github.com/thiskevinwang/dynamo-next-graphql/pull/4

Add `updateUserAvatarUrl` field/resolver to update a user's `avatarUrl` 
- there's probably a better way to use one resolver.