### PR TITLE
Modularize schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.6.1] - 2020-05-03
+
+### Changes
+
+Split up _monolithic_ `typeDefs` in `schema.graphql.ts`
+
+- use multiple `gql` tags, and `extend type Query/Mutation`
+
+### Todo
+
+Co-locate TypeScript interfaces and GraphQL typedefs.
+
+- This will be significantly easier to grok, and update
+
+Rethink `/resolvers` folder structure
+
+- ❌ separating by `/Query` & `/Mutation` no longer makes sense.
+- ✅ separate by "Entity" or "Domain" probably makes more sense.
+
 ## [v0.6.0] - 2020-05-03
 
 ### Changes

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import { ApolloServer, PubSub } from "apollo-server"
 import { Request, Response } from "express"
 
-import { typeDefs } from "./src/schema.graphql"
+import * as typeDefs from "./src/schema.graphql"
 import { resolvers } from "./src/resolvers"
 import { AWS, dynamoDb, docClient, s3 } from "./src/context/aws"
 import { AuthDirective, DevelopmentDirective } from "./src/directives"
@@ -18,7 +18,7 @@ export interface Context {
 }
 
 const server = new ApolloServer({
-  typeDefs,
+  typeDefs: Object.values(typeDefs),
   schemaDirectives: {
     development: DevelopmentDirective,
     auth: AuthDirective,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamodb-graphql-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "",
   "main": "index.ts",
   "scripts": {

--- a/src/schema.graphql.ts
+++ b/src/schema.graphql.ts
@@ -1,11 +1,15 @@
 import { gql } from "apollo-server"
 
-export const typeDefs = gql`
+export const dataScalarTypeDef = gql`
   scalar Date
+`
 
+export const directivesTypeDef = gql`
   directive @development on FIELD_DEFINITION
   directive @auth on FIELD_DEFINITION
+`
 
+export const dynamoTableTypeDef = gql`
   type ProvisionedThroughput {
     LastIncreaseDateTime: String
     LastDecreaseDateTime: String
@@ -40,6 +44,14 @@ export const typeDefs = gql`
     TableDescription: TableDescription
   }
 
+  extend type Mutation {
+    createTable: Table @development @auth
+  }
+  extend type Query {
+    listTables: [String] @auth
+  }
+`
+export const productTypeDef = gql`
   type Product {
     PK: ID
     SK: String
@@ -47,7 +59,18 @@ export const typeDefs = gql`
     updatedAt: Date
     productName: String
   }
-
+  extend type Mutation {
+    createProduct(productName: String!): Product @auth
+    updateProduct(productName: String!): Product @auth
+  }
+  extend type Query {
+    getProduct(productName: String!): Product
+    queryProducts: [Product]
+    queryProductsByName(productName: String): [Product]
+    scanProductsTable: [Product] @development @auth
+  }
+`
+export const userTypeDef = gql`
   type User {
     PK: ID
     SK: String
@@ -59,7 +82,17 @@ export const typeDefs = gql`
     email: String
     avatarUrl: String
   }
+  extend type Mutation {
+    createUser(username: String!, email: String!): User @development
+    updateUserAvatarUrl(avatarUrl: String!): User @auth
+  }
+  extend type Query {
+    getUser(username: String!, email: String!): User
+    queryUsers: [User]
+  }
+`
 
+export const voteTypeDef = gql`
   type Vote {
     PK: ID
     SK: String
@@ -70,6 +103,17 @@ export const typeDefs = gql`
     username: String
   }
 
+  extend type Mutation {
+    createVote(productName: String!, username: String!): Vote @auth
+  }
+
+  extend type Query {
+    queryVotesByEmail(email: String): [Vote]
+    queryVotesByProduct(productName: String): [Vote]
+  }
+`
+
+export const authTypeDef = gql`
   type S3Payload {
     signedPutObjectUrl: String!
     objectUrl: String!
@@ -78,14 +122,8 @@ export const typeDefs = gql`
   type AuthPayload {
     token: String!
   }
-  type Mutation {
-    createProduct(productName: String!): Product @auth
-    createTable: Table @development @auth
-    createUser(username: String!, email: String!): User @development
-    createVote(productName: String!, username: String!): Vote @auth
-    updateProduct(productName: String!): Product @auth
-    updateUserAvatarUrl(avatarUrl: String!): User @auth
-    #
+
+  extend type Mutation {
     login(email: String!, password: String!, username: String!): AuthPayload
     signup(
       email: String!
@@ -104,16 +142,13 @@ export const typeDefs = gql`
       fileSize: Int!
     ): S3Payload! @auth
   }
+`
 
-  type Query {
-    listTables: [String] @auth
-    getProduct(productName: String!): Product
-    getUser(username: String!, email: String!): User
-    queryProducts: [Product]
-    queryProductsByName(productName: String): [Product]
-    queryUsers: [User]
-    queryVotesByEmail(email: String): [Vote]
-    queryVotesByProduct(productName: String): [Vote]
-    scanProductsTable: [Product] @development @auth
-  }
+/**
+ * For 'empty base typed', omit `{}`
+ * @see https://github.com/ardatan/graphql-tools/issues/450#issuecomment-431008246
+ */
+export const baseTypeDef = gql`
+  type Mutation
+  type Query
 `


### PR DESCRIPTION
# Description

## [v0.6.1] - 2020-05-03

### Changes

Split up _monolithic_ `typeDefs` in `schema.graphql.ts`

- use multiple `gql` tags, and `extend type Query/Mutation`

### Todo

Co-locate TypeScript interfaces and GraphQL typedefs.

- This will be significantly easier to grok, and update

Rethink `/resolvers` folder structure

- ❌ separating by `/Query` & `/Mutation` no longer makes sense.
- ✅ separate by "Entity" or "Domain" probably makes more sense.